### PR TITLE
fix: Configure API base URL to resolve login Not Found error

### DIFF
--- a/frontend/src/services/api/core/OpenAPI.ts
+++ b/frontend/src/services/api/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: '', // Assuming API is served from the same origin or proxied
+    BASE: 'http://127.0.0.1:8000',
     VERSION: '0.1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',


### PR DESCRIPTION
I updated the `OpenAPI.BASE` URL in `frontend/src/services/api/core/OpenAPI.ts` to `http://127.0.0.1:8000`.

This change ensures that the frontend API client correctly targets the backend server, resolving the 404 Not Found error you previously encountered during login attempts. No proxy was configured in `package.json`.