### PR TITLE
Add pagination to EmployeesPage

### DIFF
--- a/frontend/src/pages/EmployeesPage/EmployeesPage.tsx
+++ b/frontend/src/pages/EmployeesPage/EmployeesPage.tsx
@@ -1,36 +1,54 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Container, Typography, Table, TableBody, TableCell, TableContainer,
-  TableHead, TableRow, Paper, Button, CircularProgress, Alert, IconButton
+  TableHead, TableRow, Paper, Button, CircularProgress, Alert, IconButton, Box
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import { EmployeesService, EmployeeInDB } from '../../services/api';
+
+const ROWS_PER_PAGE = 10;
 
 const EmployeesPage: React.FC = () => {
   const [employees, setEmployees] = useState<EmployeeInDB[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState<number>(0); // 0-indexed for skip calculation
+  // We don't have total count from the API yet, so we'll disable 'Next' if fewer than ROWS_PER_PAGE are returned.
+  const [canGoNext, setCanGoNext] = useState<boolean>(true);
+
+
+  const fetchEmployees = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const skip = currentPage * ROWS_PER_PAGE;
+      const response = await EmployeesService.readEmployeesApiV1EmployeesGet(skip, ROWS_PER_PAGE);
+      setEmployees(response);
+      // If the number of employees returned is less than ROWS_PER_PAGE, we're on the last page.
+      setCanGoNext(response.length === ROWS_PER_PAGE);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch employees');
+      console.error(err);
+      setCanGoNext(false); // Disable next on error
+    } finally {
+      setLoading(false);
+    }
+  }, [currentPage]);
 
   useEffect(() => {
-    const fetchEmployees = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const response = await EmployeesService.readEmployeesApiV1EmployeesGet(0, 100); // Default skip 0, limit 100
-        setEmployees(response);
-      } catch (err: any) {
-        setError(err.message || 'Failed to fetch employees');
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchEmployees();
-  }, []);
+  }, [fetchEmployees]);
 
-  if (loading) {
+  const handleNextPage = () => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  };
+
+  const handlePreviousPage = () => {
+    setCurrentPage((prevPage) => Math.max(0, prevPage - 1));
+  };
+
+  if (loading && employees.length === 0) { // Show loading only on initial load or when employees are empty
     return (
       <Container sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
         <CircularProgress />
@@ -98,6 +116,25 @@ const EmployeesPage: React.FC = () => {
           </TableBody>
         </Table>
       </TableContainer>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
+        <Button
+          variant="contained"
+          onClick={handlePreviousPage}
+          disabled={currentPage === 0 || loading}
+        >
+          Previous
+        </Button>
+        <Typography variant="body1">
+          Page {currentPage + 1}
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={handleNextPage}
+          disabled={!canGoNext || loading}
+        >
+          Next
+        </Button>
+      </Box>
     </Container>
   );
 };


### PR DESCRIPTION
- Limits the number of rows displayed to 10 per page.
- Adds 'Next' and 'Previous' buttons for navigation.
- Displays the current page number.
- Updates data fetching to use skip/limit parameters based on the current page.